### PR TITLE
Allow transition to 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## Unreleased
 
-* Creating aliases for classes to avoid collisions with upcoming 7.1.
-* Deprecating old names.
+* Added `invoke` to Boolean.
+* Creating aliases for classes to avoid collisions with upcoming PHP 7.0 by deprecating future keywords.
+* Updated tests.
+* Updated documentation.
 
 ## 2.0.0 - 2015-09-08
 

--- a/README.md
+++ b/README.md
@@ -13,13 +13,15 @@ PhpTypes
 A primitive wrappers library for PHP. Uses the best* libs available in the PHP landscape and neatly wraps them
 in a single repo, providing aliased classes and some extra features not available in the base classes.
 
+If you find any cool libs that wrap around primitives, go ahead and suggest them in the issues section!
+
 <sub>`*` Based purely on opinion, but download statistics for the respective libs definitely support the bias ;)</sub>
 
 Roadmap
 -------
 
-- [x] StringType
-- [x] BooleanType
+- [x] String
+- [x] Boolean
 - [ ] Int
 - [ ] Float
 - [x] DateTime

--- a/Tests/BooleanTypeTest.php
+++ b/Tests/BooleanTypeTest.php
@@ -17,17 +17,17 @@ class BooleanTypeTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse(new BooleanType(false) == new BooleanType(true));
     }
 
-    public function testValueOf()
+    public function testFrom()
     {
-        $this->assertEquals(new BooleanType(false), BooleanType::valueOf(false));
-        $this->assertEquals(new BooleanType(false), BooleanType::valueOf('false'));
-        $this->assertEquals(new BooleanType(false), BooleanType::valueOf(null));
-        $this->assertEquals(new BooleanType(true), BooleanType::valueOf('true'));
-        $this->assertEquals(new BooleanType(true), BooleanType::valueOf(new \StdClass()));
-        $this->assertEquals(new BooleanType(true), BooleanType::valueOf(tmpfile()));
+        $this->assertEquals(new BooleanType(false), BooleanType::from(false));
+        $this->assertEquals(new BooleanType(false), BooleanType::from('false'));
+        $this->assertEquals(new BooleanType(false), BooleanType::from(null));
+        $this->assertEquals(new BooleanType(true), BooleanType::from('true'));
+        $this->assertEquals(new BooleanType(true), BooleanType::from(new \StdClass()));
+        $this->assertEquals(new BooleanType(true), BooleanType::from(tmpfile()));
         $this->assertEquals(
             new BooleanType(false),
-            BooleanType::valueOf('any string that is not "true" evalutes to false')
+            BooleanType::from('any string that is not "true" evalutes to false')
         );
     }
 
@@ -37,7 +37,7 @@ class BooleanTypeTest extends \PHPUnit_Framework_TestCase
      */
     public function testArray()
     {
-        BooleanType::valueOf([]);
+        BooleanType::from([]);
     }
 
     /**
@@ -46,7 +46,7 @@ class BooleanTypeTest extends \PHPUnit_Framework_TestCase
      */
     public function testInteger()
     {
-        BooleanType::valueOf(99);
+        BooleanType::from(99);
     }
 
     /**
@@ -55,6 +55,6 @@ class BooleanTypeTest extends \PHPUnit_Framework_TestCase
      */
     public function testDouble()
     {
-        BooleanType::valueOf(3E-5);
+        BooleanType::from(3E-5);
     }
 }

--- a/Type/Boolean.php
+++ b/Type/Boolean.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Tdn\PhpTypes\Type;
+
+/**
+ * Class Boolean.
+ *
+ * @deprecated
+ */
+class Boolean extends BooleanType
+{
+}

--- a/Type/BooleanType.php
+++ b/Type/BooleanType.php
@@ -15,7 +15,7 @@ class BooleanType implements TypeInterface
     private $value;
 
     /**
-     * @param $bool
+     * @param mixed $bool
      */
     public function __construct($bool)
     {
@@ -35,10 +35,19 @@ class BooleanType implements TypeInterface
     }
 
     /**
+     * @deprecated
+     * @see BooleanType::from
+     */
+    public static function valueOf($mixed)
+    {
+        return static::from($mixed);
+    }
+
+    /**
      * @param mixed $mixed
      * @return static
      */
-    public static function valueOf($mixed)
+    public static function from($mixed)
     {
         return new static(self::asBool($mixed));
     }
@@ -72,5 +81,13 @@ class BooleanType implements TypeInterface
                     )
                 );
         }
+    }
+
+    /**
+     * @return bool
+     */
+    public function __invoke()
+    {
+        return $this->getValue();
     }
 }

--- a/Type/String.php
+++ b/Type/String.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Tdn\PhpTypes\Type;
+
+/**
+ * Class String.
+ *
+ * @deprecated
+ */
+class String extends StringType
+{
+}

--- a/Type/StringType.php
+++ b/Type/StringType.php
@@ -93,11 +93,19 @@ class StringType extends Stringy implements TypeInterface
     }
 
     /**
+     * @see StringType::from
+     */
+    public static function valueOf($mixed)
+    {
+        return static::from($mixed);
+    }
+
+    /**
      * @param mixed $mixed
      *
      * @return static
      */
-    public static function valueOf($mixed)
+    public static function from($mixed)
     {
         switch (strtolower(gettype($mixed))) {
             case 'boolean':

--- a/Type/TypeInterface.php
+++ b/Type/TypeInterface.php
@@ -8,6 +8,14 @@ namespace Tdn\PhpTypes\Type;
 interface TypeInterface
 {
     /**
+     * Alias for TypeInterface::from
+     *
+     * @deprecated
+     * @see TypeInterface::from
+     */
+    public static function valueOf($mixed);
+
+    /**
      * A little bit of java goodness. Should be useful in the upcoming php7.
      *
      * Returns an instance of the implementing class with it's value evaluated from the argument.
@@ -17,5 +25,5 @@ interface TypeInterface
      *
      * @return static
      */
-    public static function valueOf($mixed);
+    public static function from($mixed);
 }

--- a/docs/boolean.md
+++ b/docs/boolean.md
@@ -1,21 +1,23 @@
 BooleanType
-=======
+===========
 Class provides the following methods.
 
-* [valueOf](#valueof)
+* [from](#from)
 
-#### valueOf
+#### from
 BooleanType::valueOf($mixed)
 
 Returns the boolean (if applicable) of the evaluated variable.
 
 ```php
-$boolean = BooleanType::valueOf(false);
+$boolean = BooleanType::from(false);
 var_dump($boolean->getValue()) //false
 
-$boolean = BooleanType::valueOf(new \StdClass());
+$boolean = BooleanType::from(new \StdClass());
 var_dump($boolean->getValue()) //true
 
-$boolean = BooleanType::valueOf("true");
+$boolean = BooleanType::from("true");
 var_dump($boolean->getValue()) //true
 ```
+
+See tests for other uses.

--- a/docs/datetime.md
+++ b/docs/datetime.md
@@ -1,5 +1,5 @@
-StringType
-======
+DateTime
+========
 Currently this class extends [briannesbitt/Carbon](https://github.com/briannesbitt/Carbon) and provides no additional
 methods.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,7 @@ Use docs
 --------
 Please refer to the appropriate class to read it's documentation
 
+- [BooleanType]
 - [StringType]
 - [DateTime]
 
@@ -12,5 +13,6 @@ API docs
 --------
 [ reserved ]
 
+[BooleanType]: boolean.md
 [StringType]: string.md
 [DateTime]: datetime.md

--- a/docs/string.md
+++ b/docs/string.md
@@ -7,7 +7,7 @@ Currently this class extends [danielstjules/Stringy](https://github.com/danielst
 * [singularize](#singularize)
 * [strpos](#strpos)
 * [strrpos](#strrpos)
-* [valueOf](#valueof)
+* [from](#from)
 
 #### pluralize
 $string->pluralize()
@@ -54,15 +54,17 @@ $position = StringType::create($sentence)->strrpos('ipsum');
 echo $position; //6
 ```
 
-#### valueOf
-StringType::valueOf($mixed)
+#### from
+StringType::from($mixed)
 
 Returns the evaluated value of $mixed as a string.
 
 ```php
-$newString = StringType::valueOf($myObj);
+$newString = StringType::from($myObj);
 echo $newString //"foo" aka whatever __toString is
 
-$newString = StringType::valueOf(1.895);
+$newString = StringType::from(1.895);
 echo $newString //"1.895"
 ```php
+
+See tests for other usages.


### PR DESCRIPTION
- Added `invoke` to Boolean.
- Creating aliases for classes to avoid collisions with upcoming PHP 7.0 by deprecating future keywords.
- Updated tests.
- Updated documentation.
